### PR TITLE
feat: monetized consent via bid_value

### DIFF
--- a/api/models/schemas.py
+++ b/api/models/schemas.py
@@ -64,6 +64,7 @@ class ConsentRequest(BaseModel):
     developer_token: str  # Developer's API key
     scope: str  # e.g. "attr.food.*", "world_model.read"
     expiry_hours: int = 24  # How long consent lasts
+    bid_value: Optional[float] = None  # Monetary value offered for consent (USD)
 
 
 class ConsentResponse(BaseModel):

--- a/api/routes/developer.py
+++ b/api/routes/developer.py
@@ -280,7 +280,11 @@ async def request_consent(request: ConsentRequest):
         request_id=request_id,
         scope_description=get_scope_description(scope_dot),
         poll_timeout_at=poll_timeout_at,
-        metadata={"developer_name": dev_info["name"], "expiry_hours": request.expiry_hours},
+        metadata={
+            "developer_name": dev_info["name"],
+            "expiry_hours": request.expiry_hours,
+            **({"bid_value": request.bid_value} if request.bid_value is not None else {}),
+        },
     )
     logger.info("developer_api.request_created request_id=%s scope=%s", request_id, scope_dot)
 

--- a/hushh_mcp/services/consent_db.py
+++ b/hushh_mcp/services/consent_db.py
@@ -114,6 +114,8 @@ class ConsentDBService:
                             metadata = {}
                     expiry_hours = metadata.get("expiry_hours", 24)
 
+                    bid_value = metadata.get("bid_value")
+
                     results.append(
                         {
                             "id": row.get("request_id"),
@@ -123,6 +125,7 @@ class ConsentDBService:
                             "requestedAt": row.get("issued_at"),
                             "pollTimeoutAt": poll_timeout_at,
                             "expiryHours": expiry_hours,
+                            **({"bidValue": bid_value} if bid_value is not None else {}),
                         }
                     )
 
@@ -154,6 +157,7 @@ class ConsentDBService:
                         metadata = json.loads(metadata) if metadata else {}
                     except json.JSONDecodeError:
                         metadata = {}
+                bid_value = metadata.get("bid_value")
                 return {
                     "request_id": row.get("request_id"),
                     "developer": row.get("agent_id"),
@@ -162,6 +166,7 @@ class ConsentDBService:
                     "poll_timeout_at": row.get("poll_timeout_at"),
                     "issued_at": row.get("issued_at"),
                     "metadata": metadata,
+                    **({"bid_value": bid_value} if bid_value is not None else {}),
                 }
         return None
 
@@ -344,26 +349,28 @@ class ConsentDBService:
                     metadata = None
 
             token_id = row.get("token_id")
-            items.append(
-                {
-                    "id": str(row.get("id")),
-                    "token_id": token_id[:20] + "..."
-                    if token_id and len(token_id) > 20
-                    else token_id or "N/A",
-                    "agent_id": row.get("agent_id"),
-                    "scope": row.get("scope"),
-                    "action": row.get("action"),
-                    "issued_at": row.get("issued_at"),
-                    "expires_at": row.get("expires_at"),
-                    "request_id": row.get("request_id"),
-                    "scope_description": row.get("scope_description"),
-                    "metadata": metadata,
-                    # Detect timed out: REQUESTED with poll_timeout_at in the past
-                    "is_timed_out": row.get("action") == "REQUESTED"
-                    and row.get("poll_timeout_at")
-                    and row.get("poll_timeout_at") < now_ms,
-                }
-            )
+            bid_value = metadata.get("bid_value") if metadata else None
+            item = {
+                "id": str(row.get("id")),
+                "token_id": token_id[:20] + "..."
+                if token_id and len(token_id) > 20
+                else token_id or "N/A",
+                "agent_id": row.get("agent_id"),
+                "scope": row.get("scope"),
+                "action": row.get("action"),
+                "issued_at": row.get("issued_at"),
+                "expires_at": row.get("expires_at"),
+                "request_id": row.get("request_id"),
+                "scope_description": row.get("scope_description"),
+                "metadata": metadata,
+                # Detect timed out: REQUESTED with poll_timeout_at in the past
+                "is_timed_out": row.get("action") == "REQUESTED"
+                and row.get("poll_timeout_at")
+                and row.get("poll_timeout_at") < now_ms,
+            }
+            if bid_value is not None:
+                item["bid_value"] = bid_value
+            items.append(item)
 
         return {
             "items": items,


### PR DESCRIPTION
## Summary

Integrates Rohan Sidankar's **monetized consent** concept from [app_apis](https://github.com/hushh-labs/app_apis) into the production consent protocol. Developers can now attach an optional `bid_value` (USD amount) when requesting user consent, enabling users to see the monetary value offered for their data before approving or denying.

- Added `bid_value: Optional[float]` to `ConsentRequest` schema
- Passes `bid_value` through the existing `metadata` JSONB column (no migration needed)
- Surfaces `bidValue` in pending consent requests so the approval UI can display it
- Includes `bid_value` in audit log entries for compliance tracking

### Background

Rohan's original implementation in `app_apis` stored `bid_value` as a column on a `card_consent_request` table. The consent-protocol already uses a `metadata JSONB` column on `consent_audit`, so this integration stores `bid_value` there — zero schema changes required.

### How it works

```json
POST /api/v1/request-consent
{
  "user_id": "user123",
  "developer_token": "dev-token",
  "scope": "attr.food.*",
  "expiry_hours": 24,
  "bid_value": 5.00
}
```

The `bid_value` flows through to:
1. **Pending requests** → `GET /api/consent/pending` returns `bidValue` field
2. **Audit log** → `bid_value` appears in audit history items
3. **Approve flow** → `get_pending_by_request_id()` includes `bid_value` for downstream use

## Test plan

- [ ] Verify `POST /api/v1/request-consent` accepts optional `bid_value` field
- [ ] Verify requests without `bid_value` still work (backward compatible)
- [ ] Verify `GET /api/consent/pending` returns `bidValue` when present
- [ ] Verify audit log includes `bid_value` for consent events that carry it
- [ ] Verify `bid_value` does not appear in responses when not set (no null pollution)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional monetary value data in consent requests. The system now accepts and propagates bid value information through consent request workflows, enabling financial data association with consent offers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->